### PR TITLE
feat: add comman line argument parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.6", features = ["cargo", "string"] }
+color-eyre = "0.6.2"
+eyre = "0.6.8"
+serde = { version = "1.0.188", features = ["derive"] }
+toml = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.6", features = ["cargo", "string"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,51 @@
+use eyre::Result;
+
+use crate::command;
+use crate::manifesto::Manifesto;
+
+pub struct App {
+    manifesto: Manifesto,
+}
+
+impl App {
+    pub fn new() -> Result<Self> {
+        Ok(App {
+            manifesto: Manifesto::load()?,
+        })
+    }
+
+    pub fn run(&self) -> Result<()> {
+        let subcommands = self.manifesto.largo_subcommands()
+            .into_iter()
+            .map(|s| s.clone())
+            .collect::<Vec<_>>();
+        let mut command = command::build_parser(&subcommands);
+        let matches = command.clone().get_matches();
+
+        match matches.subcommand() {
+            Some((subcommand, matches)) => {
+                self.process_subcommand(subcommand, matches)?
+            },
+            None => command.print_help()?,
+        }
+
+        Ok(())
+    }
+
+    fn process_subcommand(&self, name: &str, matches: &clap::ArgMatches) -> Result<()> {
+        let mut args = vec![self.manifesto.ledger_bin().to_owned()];
+        let mut ledger_args = self.manifesto.ledger_args(name).unwrap().clone();
+        let mut default_options = self.manifesto.ledger_default_options().clone();
+        args.append(&mut ledger_args);
+        args.append(&mut default_options);
+
+        if matches.get_flag("dry-run") {
+            let args = args.as_slice().join(" ");
+            println!("{args}");
+        } else {
+            unimplemented!();
+        }
+
+        Ok(())
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,82 @@
+use clap::{command, value_parser};
+
+pub fn build_parser(subcommands: &[String]) -> clap::Command {
+    let command = command!();
+
+    let file_name_arg = clap::Arg::new("file-name")
+        .value_parser(value_parser!(String));
+
+    let subcommands: Vec<clap::Command> = subcommands
+        .into_iter()
+        .map(|s| {
+            let s = s.clone();
+            clap::Command::new(s)
+                .arg(file_name_arg.clone())
+        })
+        .collect();
+
+    command.subcommands(&subcommands)
+}
+
+#[cfg(test)]
+mod test {
+    use super::build_parser;
+
+    fn subcommands() -> Vec<String> {
+        vec![String::from("bs"), String::from("pl")]
+    }
+
+    #[test]
+    fn parse_no_args() {
+        let args = vec!["largo"];
+        let matches = build_parser(&subcommands())
+            .try_get_matches_from(args)
+            .unwrap();
+        assert!(!matches.args_present());
+    }
+
+    #[test]
+    fn parse_bs_subcommand() {
+        let args = vec!["largo", "bs"];
+
+        let matches = build_parser(&subcommands())
+            .try_get_matches_from(&args)
+            .unwrap();
+
+        assert!(matches!(matches.subcommand(), Some(("bs", _))));
+    }
+
+    #[test]
+    fn parse_pl_subcommand() {
+        let args = vec!["largo", "pl"];
+
+        let matches = build_parser(&subcommands())
+            .try_get_matches_from(&args)
+            .unwrap();
+
+        assert!(matches!(matches.subcommand(), Some(("pl", _))));
+    }
+
+    #[test]
+    fn parse_undefined_subcommand() {
+        let args = vec!["largo", "foo"];
+
+        let matches = build_parser(&subcommands()).try_get_matches_from(&args);
+
+        assert!(matches.is_err());
+    }
+
+    #[test]
+    fn parse_bs_subcommand_with_year() {
+        let args = vec!["largo", "bs", "2022"];
+
+        let matches = build_parser(&subcommands())
+            .try_get_matches_from(&args)
+            .unwrap();
+
+        assert!(matches!(matches.subcommand(), Some(("bs", _))));
+
+        let (_, submatches) = matches.subcommand().unwrap();
+        assert_eq!(submatches.get_one("file-name"), Some(&String::from("2022")));
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,17 +1,15 @@
-use clap::{command, value_parser};
+use clap::command;
 
 pub fn build_parser(subcommands: &[String]) -> clap::Command {
     let command = command!();
-
-    let file_name_arg = clap::Arg::new("file-name")
-        .value_parser(value_parser!(String));
 
     let subcommands: Vec<clap::Command> = subcommands
         .into_iter()
         .map(|s| {
             let s = s.clone();
             clap::Command::new(s)
-                .arg(file_name_arg.clone())
+                .arg(clap::Arg::new("file-name"))
+                .arg(clap::Arg::new("dry-run").long("dry-run").action(clap::ArgAction::SetTrue))
         })
         .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod app;
 pub mod command;
+pub mod manifesto;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use largo_rs::command::build_parser;
+
 fn main() {
-    println!("Hello, world!");
+    let _ = build_parser(&[]).get_matches();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,12 @@
-use largo_rs::command::build_parser;
+use eyre::Result;
 
-fn main() {
-    let _ = build_parser(&[]).get_matches();
+use largo_rs::app::App;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let app = App::new()?;
+    app.run()?;
+
+    Ok(())
 }

--- a/src/manifesto.rs
+++ b/src/manifesto.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+
+use eyre::{Result, WrapErr};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Manifesto {
+    project: Project,
+    ledger: Ledger,
+    #[serde(flatten)]
+    commands: Commands,
+}
+
+#[derive(Deserialize)]
+pub struct Project {
+    pub largo: String,
+}
+
+#[derive(Deserialize)]
+pub struct Ledger {
+    pub bin: String,
+    #[serde(rename = "default-options")]
+    pub default_options: Vec<String>,
+}
+
+#[derive(Deserialize)]
+pub struct Commands {
+    commands: HashMap<String, Vec<String>>,
+}
+
+impl Manifesto {
+    /// Load the project manifesto file in the current directory
+    pub fn load() -> Result<Self> {
+        let s = std::fs::read_to_string("Largo.toml")
+            .wrap_err("Failed to open or read the file Largo.toml")?;
+
+        Self::load_from_str(s.as_str())
+    }
+
+    pub fn load_from_str(s: &str) -> Result<Self> {
+        toml::from_str(s).wrap_err("Failed to parse TOML file")
+    }
+
+    pub fn largo(&self) -> &str {
+        self.project.largo.as_str()
+    }
+
+    pub fn largo_subcommands(&self) -> impl Iterator<Item=&String> {
+        self.commands.names()
+    }
+
+    pub fn ledger_bin(&self) -> &str {
+        self.ledger.bin.as_str()
+    }
+
+    pub fn ledger_default_options(&self) -> &Vec<String> {
+        &self.ledger.default_options
+    }
+
+    pub fn ledger_args(&self, subcommand: &str) -> Option<&Vec<String>> {
+        self.commands.get(subcommand)
+    }
+}
+
+impl Commands {
+    pub fn get(&self, name: &str) -> Option<&Vec<String>> {
+        self.commands.get(name)
+    }
+
+    pub fn names(&self) -> impl Iterator<Item=&String> {
+        self.commands.keys()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Manifesto;
+
+    const LARGO_TOML: &str = r#"
+[project]
+largo = "largo-rs"
+
+[ledger]
+bin = "/opt/local/bin/ledger"
+default-options = ["--no-pager", "--force-color"]
+
+[commands]
+bs = ["balance", "-V", "^資産", "^負債", "^純資産"]
+pl = ["balance", "^収益", "^費用"]
+"#;
+
+    #[test]
+    fn load_project_manifesto() {
+        let manifesto = Manifesto::load_from_str(LARGO_TOML).unwrap();
+
+        assert_eq!(manifesto.largo(), "largo-rs");
+        assert_eq!(manifesto.ledger_bin(), "/opt/local/bin/ledger");
+        assert_eq!(
+            manifesto.ledger_default_options(),
+            &vec![String::from("--no-pager"), String::from("--force-color")]
+        );
+
+        let want: Vec<String> = ["balance", "-V", "^資産", "^負債", "^純資産"]
+            .into_iter()
+            .map(|s| s.to_owned())
+            .collect();
+        let got = manifesto.ledger_args("bs");
+        assert_eq!(got, Some(&want));
+
+        let want: Vec<String> = ["balance", "^収益", "^費用"]
+            .into_iter()
+            .map(|s| s.to_owned())
+            .collect();
+        let got = manifesto.ledger_args("pl");
+        assert_eq!(got, Some(&want));
+
+        assert_eq!(manifesto.ledger_args("foobar"), None);
+    }
+}

--- a/tests/examples/default/Largo.toml
+++ b/tests/examples/default/Largo.toml
@@ -1,0 +1,11 @@
+[project]
+largo = "largo-rs"
+
+[ledger]
+bin = "/opt/local/bin/ledger"
+default-options = ["--no-pager", "--force-color"]
+
+[commands]
+bs = ["balance", "-V", "^資産", "^負債", "^純資産"]
+pl = ["balance", "^収益", "^費用"]
+

--- a/tests/largo.rs
+++ b/tests/largo.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+#[test]
+fn largo_invoked_without_arguments_should_succeed() {
+    let largo = std::fs::canonicalize("target/debug/largo-rs").unwrap();
+    let output = Command::new(largo.as_path())
+        .current_dir("tests/examples/default")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "largo-rs failed: {:?}", output);
+}
+
+#[test]
+fn largo_bs_with_dry_run_should_print_ledger_command() {
+    let largo = std::fs::canonicalize("target/debug/largo-rs").unwrap();
+    let output = Command::new(largo.as_path())
+        .args(["bs", "--dry-run"])
+        .current_dir("tests/examples/default")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "largo-rs failed: {:?}", output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim_end(),
+        "/opt/local/bin/ledger -f book/2023.ledger balance -V ^資産 ^負債 ^純資産 --no-pager --force-color"
+    );
+}


### PR DESCRIPTION
- [x] Parse command line arguments with `clap`.
- [x] Add subcommands from _Largo.toml_ in runtime.